### PR TITLE
Fix invalid responses and typo

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -188,7 +188,7 @@ Citizen.CreateThread(function()
 		end
 
 		
-		if decline and strikes >= settings.MaxStrikes then
+		if decline and strikes >= config.MaxStrikes then
 			deferrals.done(string)
 		else
 			deferrals.done()


### PR DESCRIPTION
I added a `validResponse` function that checks the HTTP status code and the response to ensure that it is a valid response. If the response is valid, it continues to function as usual. If it is invalid, it defaults the values to the base configured minimum to allow the player to join. I made these changes after Steam was down for a few hours and no one could join my server. It is also fairly frequent that Steam limits requests during peak times, which causes this resource to time out.

In addition, `settings.MaxStrikes` should be `config.MaxStrikes` at the bottom. This threw an error when this check needs to occur, since `settings` is not defined.